### PR TITLE
Add CLI Calculator Application

### DIFF
--- a/cli/calculator_cli.py
+++ b/cli/calculator_cli.py
@@ -1,0 +1,28 @@
+import argparse
+import calc
+
+
+def main():
+    parser = argparse.ArgumentParser(description='CLI Calculator')
+    parser.add_argument('operation', choices=['add', 'multiply', 'average'],
+                        help='Operation to perform: add, multiply, or average')
+    parser.add_argument('values', type=float, nargs='+',
+                        help='Numbers for the operation, separated by space.')
+
+    args = parser.parse_args()
+
+    if args.operation == 'add':
+        result = calc.add_numbers(args.values[0], args.values[1])
+    elif args.operation == 'multiply':
+        result = calc.multiply_numbers(args.values[0], args.values[1])
+    elif args.operation == 'average':
+        if len(args.values) % 2 != 0:
+            raise ValueError('The number of values for average must be even.')
+        mid = len(args.values) // 2
+        result = calc.calculate_average_of_two_lists(args.values[:mid], args.values[mid:])
+
+    print(f'Result: {result}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This pull request adds a new CLI calculator application under the `cli` directory that leverages the existing `calc.py` script provided in the repo.

The application allows users to perform three operations: addition, multiplication, and averaging of two lists of numbers. It uses `argparse` for command-line argument parsing.

**Usage:**
- To add two numbers: `python calculator_cli.py add 10 5`
- To multiply two numbers: `python calculator_cli.py multiply 10 5`
- To average two lists: `python calculator_cli.py average 10 20 30 40` (where the first two and the last two numbers are considered separate lists)